### PR TITLE
Fix linter file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "prefer-arrow-callback": "off",
     "func-names": "off",
     "no-param-reassign": "off",
-    "max-lines-per-function": "off"
+    "max-lines-per-function": "off",
+    "no-unused-vars": "warn"
   },
   "env": {
     "browser": true,


### PR DESCRIPTION
Renomeia arquivo .eslintrc para .eslintrc.json e adiciona regra para transformar em warning o erro de variáveis não utilizadas para que o avaliador possa ser executado corretamente mesmo antes das pessoas estudantes começarem a executar o projeto.